### PR TITLE
Update layout-ext.html to remove QA errors associated with duplicate anchor Ids

### DIFF
--- a/layouts/layout-ext.html
+++ b/layouts/layout-ext.html
@@ -148,7 +148,7 @@
                     This structure is derived from <a href="{{site.data.structuredefinitions['{{[id]}}'].basepath}}">{{site.data.structuredefinitions['{{[id]}}'].basename}}</a>
                 </p>
                 <div id="all-tbl-diff-inner">
-                    {%include StructureDefinition-{{[id]}}-diff.xhtml%}
+                  {%include StructureDefinition-{{[id]}}-diff-all.xhtml%}
                 </div>
             </div>
             <div id="all-tbl-snap">

--- a/package-list.json
+++ b/package-list.json
@@ -12,6 +12,15 @@
       "current" : true
     },
     {
+      "version" : "0.9.0",
+      "path" : "http://fhir.org/templates/hl7.au.base.template/0.9.0",
+      "status" : "release",
+      "sequence" : "Publications",
+      "fhirversion" : "4.0.1",
+      "desc" : "Update extensions layout",
+      "current" : true
+    },
+    {
       "version" : "0.8.1",
       "path" : "http://fhir.org/templates/hl7.au.base.template/0.8.1",
       "status" : "release",


### PR DESCRIPTION
Update layout.ext.html to remove QA errors associated with duplicate anchor Ids.