### PR TITLE
v0.10.0: Correct the header HL7 AU logo link to point to the HL7 Australia website

### DIFF
--- a/includes/_append.fragment-header.html
+++ b/includes/_append.fragment-header.html
@@ -1,5 +1,5 @@
         <div id="hl7-nav">
-          <a id="hl7-logo" no-external="true" href="http://hl7.org.au">
+          <a id="hl7-logo" no-external="true" href="http://hl7.com.au">
             <img height="50" alt="Visit the HL7 Australia website" src="{{site.data.info.assets}}assets/images/hl7-logo.png"/>
           </a>
         </div>

--- a/package-list.json
+++ b/package-list.json
@@ -12,13 +12,21 @@
       "current" : true
     },
     {
+      "version" : "0.10.0",
+      "path" : "http://fhir.org/templates/hl7.au.base.template/0.10.0",
+      "status" : "release",
+      "sequence" : "Publications",
+      "fhirversion" : "4.0.1",
+      "desc" : "Update the header HL7 AU logo link to point to the correct HL7 Australia website URL",
+      "current" : true
+    },
+    {
       "version" : "0.9.0",
       "path" : "http://fhir.org/templates/hl7.au.base.template/0.9.0",
       "status" : "release",
       "sequence" : "Publications",
       "fhirversion" : "4.0.1",
       "desc" : "Update extensions layout",
-      "current" : true,
       "date" : "2024-11-12"
     },
     {

--- a/package/package.json
+++ b/package/package.json
@@ -9,5 +9,5 @@
   "dependencies" : {
     "fhir.base.template" : "current"
   },
-  "version" : "0.9.0"
+  "version" : "0.10.0"
 }


### PR DESCRIPTION
Point to HL7 Australia website https://hl7.com.au/ from the header HL7 AU logo. 